### PR TITLE
Separate performance counters into another window

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -5,14 +5,25 @@ import control.{DataTreeView, PerfTreeView, SharedAxisCharts}
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
 import scalafx.scene.Scene
-import scalafx.scene.control.SplitPane
+import scalafx.scene.control.{Label, SplitPane}
 import scalafx.scene.layout.VBox.setVgrow
-import scalafx.scene.layout.{Priority, VBox}
+import scalafx.scene.layout.{GridPane, Priority, VBox}
 import scalafx.stage.Stage
 
 
 object Main extends JFXApp {
-  println(s"Rendering pipeline: ${com.sun.prism.GraphicsPipeline.getPipeline.getClass.getName}")
+  val perfTree = new PerfTreeView()
+  val perfStage = new Stage() {
+    title = "Performance"
+    scene = new Scene {
+      root = new GridPane() {
+        add(new Label(s"Rendering pipeline: ${com.sun.prism.GraphicsPipeline.getPipeline.getClass.getName}"), 0, 0)
+        add(perfTree, 0, 1)
+      }
+    }
+  }
+  perfStage.show()
+
 
   // See layouts documentation
   // https://docs.oracle.com/javafx/2/layout/builtin_layouts.htm
@@ -41,13 +52,4 @@ object Main extends JFXApp {
       root = splitPane
     }
   }
-
-  val perfTree = new PerfTreeView()
-  val perfStage = new Stage() {
-    title = "Performance"
-    scene = new Scene {
-      root = perfTree
-    }
-  }
-  perfStage.show()
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -53,5 +53,8 @@ object Main extends JFXApp {
       splitPane.setDividerPositions(0.25)
       root = splitPane
     }
+    onCloseRequest = { _ =>
+      perfStage.close()  // also close the performance window when the main window closes
+    }
   }
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,6 +1,6 @@
 package bigvis
 
-import control.{DataTreeView, SharedAxisCharts}
+import control.{DataTreeView, PerfTreeView, SharedAxisCharts}
 
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
@@ -8,6 +8,7 @@ import scalafx.scene.Scene
 import scalafx.scene.control.SplitPane
 import scalafx.scene.layout.VBox.setVgrow
 import scalafx.scene.layout.{Priority, VBox}
+import scalafx.stage.Stage
 
 
 object Main extends JFXApp {
@@ -40,4 +41,13 @@ object Main extends JFXApp {
       root = splitPane
     }
   }
+
+  val perfTree = new PerfTreeView()
+  val perfStage = new Stage() {
+    title = "Performance"
+    scene = new Scene {
+      root = perfTree
+    }
+  }
+  perfStage.show()
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -7,7 +7,7 @@ import scalafx.application.JFXApp.PrimaryStage
 import scalafx.scene.Scene
 import scalafx.scene.control.{Label, SplitPane}
 import scalafx.scene.layout.VBox.setVgrow
-import scalafx.scene.layout.{GridPane, Priority, VBox}
+import scalafx.scene.layout.{Priority, VBox}
 import scalafx.stage.Stage
 
 
@@ -16,9 +16,11 @@ object Main extends JFXApp {
   val perfStage = new Stage() {
     title = "Performance"
     scene = new Scene {
-      root = new GridPane() {
-        add(new Label(s"Rendering pipeline: ${com.sun.prism.GraphicsPipeline.getPipeline.getClass.getName}"), 0, 0)
-        add(perfTree, 0, 1)
+      root = new VBox {
+        children = Seq(
+          new Label(s"Rendering pipeline: ${com.sun.prism.GraphicsPipeline.getPipeline.getClass.getName}"),
+          perfTree
+        )
       }
     }
   }

--- a/src/main/scala/control/BaseBTreeChart.scala
+++ b/src/main/scala/control/BaseBTreeChart.scala
@@ -4,10 +4,7 @@ package control
 import btree._
 
 import javafx.scene.paint.Color
-import scalafx.Includes._
-import scalafx.scene.input.{DragEvent, TransferMode}
 import scalafx.scene.layout.StackPane
-import scalafx.scene.shape.Rectangle
 
 import java.time.{Instant, ZoneId, ZoneOffset, ZonedDateTime}
 

--- a/src/main/scala/control/DataTreeView.scala
+++ b/src/main/scala/control/DataTreeView.scala
@@ -1,4 +1,6 @@
-package bigvis.control
+package bigvis
+package control
+
 import bigvis.{BTreeSeries, CsvLoader}
 import scalafx.Includes._
 import scalafx.beans.property.StringProperty

--- a/src/main/scala/control/DataTreeView.scala
+++ b/src/main/scala/control/DataTreeView.scala
@@ -24,6 +24,7 @@ class DataTreeView extends TreeTableView[DataTreeItem]() {
     expanded = true
     children = Seq()
   })
+  this.setShowRoot(false)
 
   // All data items available, used for drag-and-drop
   val dataItems = mutable.HashMap[String, BTreeSeries]()

--- a/src/main/scala/control/DraggableBTreeChartWrapper.scala
+++ b/src/main/scala/control/DraggableBTreeChartWrapper.scala
@@ -37,6 +37,7 @@ class DraggableBTreeChartWrapper(chart: BaseBTreeChart) extends StackPane {
     event.dragboard.content.get(DataTreeView.BTreeDataType) match {
       case Some(str: String) => chart.container.dataItems.get(str).foreach { bTreeData =>
         chart.addDataset(bTreeData)
+        PerfTreeView().foreach(_.addItem(bTreeData.name))
         dragRect.setFill(Color.TRANSPARENT)
       }
       case _ => // shouldn't get here

--- a/src/main/scala/control/DraggableBTreeChartWrapper.scala
+++ b/src/main/scala/control/DraggableBTreeChartWrapper.scala
@@ -36,8 +36,8 @@ class DraggableBTreeChartWrapper(chart: BaseBTreeChart) extends StackPane {
   dragRect.onDragDropped = (event: DragEvent) => {
     event.dragboard.content.get(DataTreeView.BTreeDataType) match {
       case Some(str: String) => chart.container.dataItems.get(str).foreach { bTreeData =>
-        chart.addDataset(bTreeData)
         PerfTreeView().foreach(_.addItem(bTreeData.name))
+        chart.addDataset(bTreeData)
         dragRect.setFill(Color.TRANSPARENT)
       }
       case _ => // shouldn't get here

--- a/src/main/scala/control/FloatBTreeChart.scala
+++ b/src/main/scala/control/FloatBTreeChart.scala
@@ -136,9 +136,13 @@ class FloatBTreeChart(parent: SharedAxisCharts, timeBreak: Long)
 
     windowSections.clear()
     val charts = datasets.map { dataset =>
-      val (sections, chartMetadata) = getData(scale, dataset.tree)
+      val (sections, perf) = getData(scale, dataset.tree)
       windowSections.put(dataset.name, sections)
-      (dataset, chartMetadata, sections)
+
+      PerfTreeView().foreach(_.updateItemPerf(dataset.name,
+        perf.nodes, perf.resampledNodes, perf.nodeTime, perf.sectionTime, perf.resampleTime
+      ))
+      (dataset, sections)
     }
 
     chartCanvas.draw(scale, charts.toSeq)

--- a/src/main/scala/control/PerfTreeView.scala
+++ b/src/main/scala/control/PerfTreeView.scala
@@ -46,20 +46,22 @@ class PerfTreeView extends TreeTableView[PerfTreeItem]() {
     items.put(name, newItem)
   }
 
+  // Update the data processing related performance stats for an item
   def updateItemPerf(name: String, nodeCount: Long, resampleNodeCount: Long,
                      nodeTime: Double, sectionTime: Double, resampleTime: Double): Unit = {
     items.get(name).foreach { item =>
       item.nodeCountProp.setValue(nodeCount.toString)
       item.resampleNodeCountProp.setValue(resampleNodeCount.toString)
-      item.nodeTimeProp.setValue(f"${nodeTime * 1000}%.1f")
-      item.sectionTimeProp.setValue(f"${sectionTime * 1000}%.1f")
-      item.resampleTimeProp.setValue(f"${resampleTime * 1000}%.1f")
+      item.nodeTimeProp.setValue(f"${nodeTime * 1000}%.1f ms")
+      item.sectionTimeProp.setValue(f"${sectionTime * 1000}%.1f ms")
+      item.resampleTimeProp.setValue(f"${resampleTime * 1000}%.1f ms")
     }
   }
 
+  // Update the rendering performance stats for an item
   def updateItemRender(name: String, renderTime: Double): Unit = {
     items.get(name).foreach { item =>
-      item.renderTimeProp.setValue(f"${renderTime * 1000}%.1f")
+      item.renderTimeProp.setValue(f"${renderTime * 1000}%.1f ms")
     }
   }
 

--- a/src/main/scala/control/PerfTreeView.scala
+++ b/src/main/scala/control/PerfTreeView.scala
@@ -5,6 +5,14 @@ import scalafx.beans.property.StringProperty
 import scalafx.scene.control.{TreeItem, TreeTableColumn, TreeTableView}
 
 
+// Singleton
+object PerfTreeView {
+  private var instance: Option[PerfTreeView] = None
+
+  def apply(): Option[PerfTreeView] = instance
+}
+
+
 class PerfTreeItem(name: String) {
   val nameProp = StringProperty(name)
   val nodeCountProp = StringProperty("")
@@ -21,6 +29,9 @@ class PerfTreeView extends TreeTableView[PerfTreeItem]() {
     children = Seq()
   })
   this.setShowRoot(false)
+
+  require(PerfTreeView.instance.isEmpty, "PerfTreeView must be singleton")
+  PerfTreeView.instance = Some(this)  // at this point it's mutable
 
   columns ++= Seq(
     new TreeTableColumn[PerfTreeItem, String] {

--- a/src/main/scala/control/PerfTreeView.scala
+++ b/src/main/scala/control/PerfTreeView.scala
@@ -1,7 +1,7 @@
 package bigvis
 package control
 
-import scalafx.beans.property.{FloatProperty, IntegerProperty, StringProperty}
+import scalafx.beans.property.StringProperty
 import scalafx.scene.control.{TreeItem, TreeTableColumn, TreeTableView}
 
 
@@ -16,10 +16,11 @@ class PerfTreeItem(name: String) {
 
 
 class PerfTreeView extends TreeTableView[PerfTreeItem]() {
-  this.setRoot(new TreeItem(new PerfTreeItem("root", "", None)) {
+  this.setRoot(new TreeItem(new PerfTreeItem("root")) {
     expanded = true
     children = Seq()
   })
+  this.setShowRoot(false)
 
   columns ++= Seq(
     new TreeTableColumn[PerfTreeItem, String] {

--- a/src/main/scala/control/PerfTreeView.scala
+++ b/src/main/scala/control/PerfTreeView.scala
@@ -1,0 +1,50 @@
+package bigvis
+package control
+
+import scalafx.beans.property.{FloatProperty, IntegerProperty, StringProperty}
+import scalafx.scene.control.{TreeItem, TreeTableColumn, TreeTableView}
+
+
+class PerfTreeItem(name: String) {
+  val nameProp = StringProperty(name)
+  val nodeCountProp = StringProperty("")
+  val resampleNodeCountProp = StringProperty("")
+  val nodeTimeProp = StringProperty("")
+  val sectionTimeProp = StringProperty("")
+  val resampleTimeProp = StringProperty("")
+}
+
+
+class PerfTreeView extends TreeTableView[PerfTreeItem]() {
+  this.setRoot(new TreeItem(new PerfTreeItem("root", "", None)) {
+    expanded = true
+    children = Seq()
+  })
+
+  columns ++= Seq(
+    new TreeTableColumn[PerfTreeItem, String] {
+      text = "Name"
+      cellValueFactory = { _.value.value.value.nameProp }
+    },
+    new TreeTableColumn[PerfTreeItem, String] {
+      text = "Nodes"
+      cellValueFactory = { _.value.value.value.nodeCountProp }
+    },
+    new TreeTableColumn[PerfTreeItem, String] {
+      text = "Resampled Nodes"
+      cellValueFactory = { _.value.value.value.resampleNodeCountProp }
+    },
+    new TreeTableColumn[PerfTreeItem, String] {
+      text = "Node Time"
+      cellValueFactory = { _.value.value.value.nodeTimeProp }
+    },
+    new TreeTableColumn[PerfTreeItem, String] {
+      text = "Section Time"
+      cellValueFactory = { _.value.value.value.sectionTimeProp }
+    },
+    new TreeTableColumn[PerfTreeItem, String] {
+      text = "Resample Time"
+      cellValueFactory = { _.value.value.value.resampleTimeProp }
+    },
+  )
+}

--- a/src/main/scala/control/SharedAxisCharts.scala
+++ b/src/main/scala/control/SharedAxisCharts.scala
@@ -41,6 +41,7 @@ class SharedAxisCharts(val dataItems: mutable.HashMap[String, BTreeSeries]) exte
         val chart = BTreeChart.fromTree(this, bTreeData)
         setVgrow(chart, Priority.Always)
         this.items.add(new DraggableBTreeChartWrapper(chart))
+        PerfTreeView().foreach(_.addItem(bTreeData.name))
       }
       case _ =>  // shouldn't get here
     }

--- a/src/main/scala/control/SharedAxisCharts.scala
+++ b/src/main/scala/control/SharedAxisCharts.scala
@@ -38,10 +38,10 @@ class SharedAxisCharts(val dataItems: mutable.HashMap[String, BTreeSeries]) exte
           xLower.value = bTreeData.tree.minTime
           xUpper.value = bTreeData.tree.maxTime
         }
+        PerfTreeView().foreach(_.addItem(bTreeData.name))
         val chart = BTreeChart.fromTree(this, bTreeData)
         setVgrow(chart, Priority.Always)
         this.items.add(new DraggableBTreeChartWrapper(chart))
-        PerfTreeView().foreach(_.addItem(bTreeData.name))
       }
       case _ =>  // shouldn't get here
     }


### PR DESCRIPTION
Instead of cluttering the main chart with performance numbers, moves it to a separate tree view window. No change in the data collected / displayed.

The performance window is architected as a singleton, so anyone can access it from anywhere, at any time without needing to plumb it through the call hierarchy - akin to a logging utility.

Also hides the root nodes from all the tree views, since those aren't doing anything useful.